### PR TITLE
Align nuxt server url with axios base url

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+
 import { STANDARD } from './config/private-label';
 import { directiveSsr as t } from './plugins/i18n';
 import { trimWhitespaceSsr as trimWhitespace } from './plugins/trim-whitespace';
@@ -61,6 +62,10 @@ if ( pl !== STANDARD ) {
 
 console.log(`API: ${ api }`); // eslint-disable-line no-console
 
+const nuxtServer = new URL(`https://localhost:${ dev ? 8005 : 80 }`);
+
+console.log(`Nuxt Server: ${ nuxtServer.origin }`); // eslint-disable-line no-console
+
 module.exports = {
   dev,
 
@@ -95,6 +100,7 @@ module.exports = {
     https:          true,
     proxy:          true,
     retry:          { retries: 0 },
+    baseURL:        nuxtServer.origin
     // debug:   true
   },
 
@@ -298,8 +304,8 @@ module.exports = {
       key:  fs.readFileSync(path.resolve(__dirname, 'server/server.key')),
       cert: fs.readFileSync(path.resolve(__dirname, 'server/server.crt'))
     } : null),
-    port:      (dev ? 8005 : 80),
-    host:      '0.0.0.0',
+    port:      nuxtServer.port,
+    host:      nuxtServer.hostname,
   },
 
   // Server middleware


### PR DESCRIPTION
- This PR fixes the issue i've seen on my linux box when using a localhost and non-localhost `API` env, though I couldn't fully test the later due to my rancher docker container failing to start with a default local cluster
- I still see a `422 (Unprocessable Entity)` (Invalid CSRF token) error on log in when the 'CSRF' cookie value has not been set (fresh log in after clearing cookies, trying to log in again after log out, etc). Confirming if this happens on an otherwise fine system without this change would be worthwhile.
- The crux of the issue seems to be that axios's baseUrl was defaulting to the machine's hostname leading, interestingly, to `Loading error getaddrinfo ENOTFOUND <machine's host name>` on load of landing page
- This can be fixed by updating the local hosts file... but that leads to...
  - `ERR_CERT_AUTHORITY_INVALID` errors due to nuxt's proxy setting the  `x-api-host` to hostname
  - Then also CORS issues when app goes to the `API` urls directly (and not proxied via nuxt)
- This PR addresses the core issue, rather than changes in https://github.com/richard-cox/dashboard/pull/1 which work around it

